### PR TITLE
fixed NoClassDefFoundError on gradlew build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Build: `gradlew shadowJar`

--- a/build.gradle
+++ b/build.gradle
@@ -56,3 +56,7 @@ tasks.withType(JavaCompile).configureEach {
 tasks.withType(JavaCompile) {
     options.compilerArgs << "-parameters"
 }
+
+shadowJar {
+    archiveClassifier.set("")
+}


### PR DESCRIPTION
При сборке плагина через `gradlew build` появлялась ошибка:
```
[22:39:57 ERROR]: [ModernPluginLoadingStrategy] Could not load plugin 'Granter.jar' in folder 'plugins\.paper-remapped'
org.bukkit.plugin.InvalidPluginException: java.lang.NoClassDefFoundError: io/github/slimjar/logging/ProcessLogger
        at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:129) ~[purpur-1.21.jar:1.21-2272-b2d1fea]
        at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:35) ~[purpur-1.21.jar:1.21-2272-b2d1fea]
        at io.papermc.paper.plugin.entrypoint.strategy.modern.ModernPluginLoadingStrategy.loadProviders(ModernPluginLoadingStrategy.java:116) ~[purpur-1.21.jar:1.21-2272-b2d1fea]
        at io.papermc.paper.plugin.storage.SimpleProviderStorage.enter(SimpleProviderStorage.java:38) ~[purpur-1.21.jar:1.21-2272-b2d1fea]
        at io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.enter(LaunchEntryPointHandler.java:40) ~[purpur-1.21.jar:1.21-2272-b2d1fea]
        at org.bukkit.craftbukkit.CraftServer.loadPlugins(CraftServer.java:560) ~[purpur-1.21.jar:1.21-2272-b2d1fea]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:326) ~[purpur-1.21.jar:1.21-2272-b2d1fea]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1229) ~[purpur-1.21.jar:1.21-2272-b2d1fea]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:333) ~[purpur-1.21.jar:1.21-2272-b2d1fea]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.lang.NoClassDefFoundError: io/github/slimjar/logging/ProcessLogger
        at java.base/java.lang.Class.forName0(Native Method) ~[?:?]
        at java.base/java.lang.Class.forName(Class.java:534) ~[?:?]
        at java.base/java.lang.Class.forName(Class.java:513) ~[?:?]
        at org.bukkit.plugin.java.PluginClassLoader.<init>(PluginClassLoader.java:78) ~[paper-mojangapi-1.21-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:125) ~[purpur-1.21.jar:1.21-2272-b2d1fea]
        ... 9 more
Caused by: java.lang.ClassNotFoundException: io.github.slimjar.logging.ProcessLogger
        at org.bukkit.plugin.java.PluginClassLoader.loadClass0(PluginClassLoader.java:197) ~[paper-mojangapi-1.21-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.java.PluginClassLoader.loadClass(PluginClassLoader.java:164) ~[paper-mojangapi-1.21-R0.1-SNAPSHOT.jar:?]
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?]
        at java.base/java.lang.Class.forName0(Native Method) ~[?:?]
        at java.base/java.lang.Class.forName(Class.java:534) ~[?:?]
        at java.base/java.lang.Class.forName(Class.java:513) ~[?:?]
        at org.bukkit.plugin.java.PluginClassLoader.<init>(PluginClassLoader.java:78) ~[paper-mojangapi-1.21-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:125) ~[purpur-1.21.jar:1.21-2272-b2d1fea]
        ... 9 more
```

А при использовании `gradlew shadowJar` файлы проекта не добавлялись в JAR